### PR TITLE
Dzil plugin to create an instant answer change log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# p5-dzp-iachangelog
-Add an instant answer change log to a release
+# Dist::Zilla::Plugin::IAChangelog - Add instant answer change log file to releases
+
+## Synopsis
+
+During release, attempts to determine which instant answers have been added,
+modified, or deleted.  Outputs their metadata IDs and status to a YAML file.
+
+This file is used by duckpan.org to update the statuses of instant answer pages
+on the [DuckDuckHack Community Platform](https://duck.co).
+
+To activate the plugin, add the following to **dist.ini**:
+
+    [IAChangelog]
+
+## Attributes
+
+- **file_name**: Name of the file to be added to the release.  Since this is a YAML file it makes sense to use a .yml extension, though it's not required.  Defaults to 'ia_changelog.yml'.
+
+## Contributing
+
+To browse the repository, submit issues, or bug fixes, please visit
+the github repository:
+
++ https://github.com/duckduckgo/p5-dzp-iachangelog
+
+## Author
+
+Zach Thompson <zach@duckduckgo.com>

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Synopsis
 
-During release, attempts to determine which instant answers have been added,
+During release, attempts to determine which Instant Answers have been added,
 modified, or deleted.  Outputs their metadata IDs and status to a YAML file.
 
-This file is used by duckpan.org to update the statuses of instant answer pages
+This file is used by duckpan.org to update the statuses of Instant Answer pages
 on the [DuckDuckHack Community Platform](https://duck.co).
 
 To activate the plugin, add the following to **dist.ini**:

--- a/dist.ini
+++ b/dist.ini
@@ -1,4 +1,4 @@
-name    = Dist-Zilla-Plugin-BuildShareAssets 
+name    = Dist-Zilla-Plugin-IAChangelog
 author  = Zach Thompson <zach@duckduckgo.com>
 license = Apache_2_0
 copyright_holder = DuckDuckGo, Inc. L<https://duckduckgo.com/>

--- a/dist.ini
+++ b/dist.ini
@@ -1,0 +1,28 @@
+name    = Dist-Zilla-Plugin-BuildShareAssets 
+author  = Zach Thompson <zach@duckduckgo.com>
+license = Apache_2_0
+copyright_holder = DuckDuckGo, Inc. L<https://duckduckgo.com/>
+copyright_year   = 2015
+
+[PromptIfStale]
+index = http://duckpan.org
+module = Dist::Zilla::Plugin::UploadToDuckPAN
+
+[AutoPrereqs]
+
+[GatherDir]
+[PruneFiles]
+match = \.(?:ini|md)$
+[PruneCruft]
+[MakeMaker]
+[Manifest]
+[ConfirmRelease]
+[UploadToDuckPAN]
+[MetaJSON]
+
+[Git::NextVersion]
+[PkgVersion]
+[GithubMeta]
+[@Git]
+[Git::Push]
+push_to = origin master

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -1,0 +1,99 @@
+package Dist::Zilla::Plugin::IAChangelog;
+# ABSTRACT: Add instant answer change log file to distro 
+
+use Moose;
+use namespace::autoclean;
+with 'Dist::Zilla::Role::FileGatherer';
+
+use Dist::Zilla::File::InMemory;
+use DDG::Meta::Data;
+use JSON::XS 'decode_json';
+use IO::All;
+use YAML::XS 'Dump';
+
+use strict;
+
+sub gather_files {
+	my $s = shift;
+
+	my $yml = 'ia_changelog.yml';
+
+	$s->log(["Creating instant answer change log ($yml)"]);
+
+	my $m = DDG::Meta::Data->by_id;
+
+	my %share_paths;
+	while(my ($k, $v) = each %$m){
+		my $sp = $v->{perl_module};
+		$sp =~ s/^DDG:://;
+		$sp =~ s|::|/|g;
+		$sp =~ s/([a-z])([A-Z])/$1_$2/g;
+		$sp = lc $sp;
+		$sp = "share/$sp";
+		$share_paths{$sp} = $v->{id};
+	}
+
+	my $latest_tag  = (reverse(split /\s+/, `git tag -l [0-9]*`))[0];
+
+	open my $gd, "git diff $latest_tag.. --merges --name-status --diff-filter=AMD --ignore-all-space lib/ share/ |"
+		or $s->log_fatal(["Failed to execute `git diff`: $!"]);
+
+	my $ia_types = qr/(?:goodie|spice|fathead|longtail)/i;
+	my %changes;
+	while(my $x = <$gd>){
+		my ($status, $file) = split /\s+/, $x;
+		
+		my $id;
+		if($file =~ m{lib/(DDG/$ia_types/.+)\.pm$}){
+			my $m = $1;
+            $m =~ s|/|::|g;
+            if($m =~ /CheatSheets$/){
+				$id = 'cheat_sheets';
+            }
+			else{
+				if(my $ia = DDG::Meta::Data->get_ia(module => $m)){
+					unless(@$ia == 1){
+						$s->log_fatal(["Multiple IDs in metadata for module $m: @$ia"]);
+					}
+					$id = $ia->[0]{id};
+				}
+			}
+		}
+        elsif($file =~ m{share/goodie/cheat_sheets/json/.+\.json$}){
+			my $j = decode_json(io($file)->slurp);
+			$id = $j->{id};
+	    }
+		elsif($file =~ m{(share/$ia_types/.+)/.+$}){
+			my $sd = $1;
+			while(my ($sp, $meta_id) = each %share_paths){
+				$s->log(["checking if $sd contains $sp"]);
+				if($sd eq $sp){
+					$id = $meta_id;
+					# status for shared assets atm is always "modified" with respect to the IA
+					$status = 'M';
+					last
+				}
+			}
+			unless($id){
+				$s->log_fatal(["Failed to find share path for $sd in share_paths"]);
+			}
+		}
+
+		if($id){
+			$changes{$id} = $status;
+		}
+		else{
+			$s->log_debug(["No id found for $file"]);
+		}
+
+	}
+
+	my $f = Dist::Zilla::File::InMemory->new({
+		name => $yml,
+		content => Dump(\%changes) 
+	});
+
+	$s->add_file($f);
+}
+
+1;

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -13,87 +13,147 @@ use YAML::XS 'Dump';
 
 use strict;
 
+has file_name => (
+    is => 'ro',
+    default => 'ia_changelog.yml'
+);
+
 sub gather_files {
-	my $s = shift;
+    my $s = shift;
 
-	my $yml = 'ia_changelog.yml';
+    $s->log(["Creating instant answer change log (%s)", $s->file_name]);
 
-	$s->log(["Creating instant answer change log ($yml)"]);
+    my $m = DDG::Meta::Data->by_id;
 
-	my $m = DDG::Meta::Data->by_id;
+    my %share_paths;
+    # The list of acceptable share paths is derived from the module names
+    while(my ($k, $v) = each %$m){
+        my $sp = $v->{perl_module};
+        $sp =~ s/^DDG:://;
+        $sp =~ s|::|/|g;
+        $sp =~ s/([a-z])([A-Z])/$1_$2/g;
+        $sp = lc $sp;
+        $sp = "share/$sp";
+        $share_paths{$sp} = $v->{id};
+    }
 
-	my %share_paths;
-	while(my ($k, $v) = each %$m){
-		my $sp = $v->{perl_module};
-		$sp =~ s/^DDG:://;
-		$sp =~ s|::|/|g;
-		$sp =~ s/([a-z])([A-Z])/$1_$2/g;
-		$sp = lc $sp;
-		$sp = "share/$sp";
-		$share_paths{$sp} = $v->{id};
-	}
+    my $latest_tag  = (reverse(split /\s+/, `git tag -l [0-9]*`))[0];
 
-	my $latest_tag  = (reverse(split /\s+/, `git tag -l [0-9]*`))[0];
+    open my $gd, "git diff $latest_tag.. --merges --name-status --diff-filter=AMDR --ignore-all-space lib/ share/ |"
+        or $s->log_fatal(["Failed to execute `git diff`: $!"]);
 
-	open my $gd, "git diff $latest_tag.. --merges --name-status --diff-filter=AMD --ignore-all-space lib/ share/ |"
-		or $s->log_fatal(["Failed to execute `git diff`: $!"]);
+    my %decode_status = qw(
+        A added
+        D removed
+        M updated
+        R updated
+    );
 
-	my $ia_types = qr/(?:goodie|spice|fathead|longtail)/i;
-	my %changes;
-	while(my $x = <$gd>){
-		my ($status, $file) = split /\s+/, $x;
-		
-		my $id;
-		if($file =~ m{lib/(DDG/$ia_types/.+)\.pm$}){
-			my $m = $1;
+    my $ia_types = qr/(?:goodie|spice|fathead|longtail)/i;
+    my %changes;
+    while(my $x = <$gd>){
+        my ($status, $file) = split /\s+/, $x;
+
+        my $id;
+        if($file =~ m{lib/(DDG/$ia_types/.+)\.pm$}){
+            my $m = $1;
             $m =~ s|/|::|g;
             if($m =~ /CheatSheets$/){
-				$id = 'cheat_sheets';
+                $id = 'cheat_sheets';
             }
-			else{
-				if(my $ia = DDG::Meta::Data->get_ia(module => $m)){
-					unless(@$ia == 1){
-						$s->log_fatal(["Multiple IDs in metadata for module $m: @$ia"]);
-					}
-					$id = $ia->[0]{id};
-				}
-			}
-		}
+            else{
+                if(my $ia = DDG::Meta::Data->get_ia(module => $m)){
+                    unless(@$ia == 1){
+                        $s->log_fatal(["Multiple IDs in metadata for module $m: @$ia"]);
+                    }
+                    $id = $ia->[0]{id};
+                }
+            }
+        }
         elsif($file =~ m{share/goodie/cheat_sheets/json/.+\.json$}){
-			my $j = decode_json(io($file)->slurp);
-			$id = $j->{id};
-	    }
-		elsif($file =~ m{(share/$ia_types/.+)/.+$}){
-			my $sd = $1;
-			while(my ($sp, $meta_id) = each %share_paths){
-				$s->log(["checking if $sd contains $sp"]);
-				if($sd eq $sp){
-					$id = $meta_id;
-					# status for shared assets atm is always "modified" with respect to the IA
-					$status = 'M';
-					last
-				}
-			}
-			unless($id){
-				$s->log_fatal(["Failed to find share path for $sd in share_paths"]);
-			}
-		}
+            my $j = decode_json(io($file)->slurp);
+            $id = $j->{id};
+        }
+        elsif($file =~ m{(share/$ia_types/.+)/.+$}){
+            my $sd = $1;
+            while(my ($sp, $meta_id) = each %share_paths){
+                if($sd eq $sp){
+                    $id = $meta_id;
+                    # status for shared assets atm is always "modified" with respect to the IA
+                    # since even the deletion or addition of an asset doesn't imply the same for
+                    # the owning IA
+                    $status = 'M';
+                    last
+                }
+            }
+            unless($id){
+                $s->log_fatal(["Failed to find share path for $sd in share_paths"]);
+            }
+        }
 
-		if($id){
-			$changes{$id} = $status;
-		}
-		else{
-			$s->log_debug(["No id found for $file"]);
-		}
+        if($id){
+            $changes{$id} = $decode_status{$status}
+        }
+        else{
+            $s->log_debug(["No id found for $file"]);
+        }
 
-	}
+    }
 
-	my $f = Dist::Zilla::File::InMemory->new({
-		name => $yml,
-		content => Dump(\%changes) 
-	});
+    my $f = Dist::Zilla::File::InMemory->new({
+        name => $s->file_name,
+        content => Dump(\%changes)
+    });
 
-	$s->add_file($f);
+    $s->add_file($f);
 }
 
+__PACKAGE__->meta->make_immutable;
+no Moose;
+
 1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+Dist::Zilla::Plugin::IAChangelog - Add instant answer change log file to releases
+
+=head1 SYNOPSIS
+
+During release, attempts to determine which instant answers have been added,
+modified, or deleted.  Outputs their metadata IDs and status to a YAML file.
+
+This file is used by duckpan.org to update the statuses of instant answer pages
+on the L<DuckDuckHack Community Platform|https://duck.co>.
+
+To activate the plugin, add the following to F<dist.ini>:
+
+    [IAChangelog]
+
+=head1 ATTRIBUTES
+
+=head2 file_name
+
+Name of the file to be added to the release.  Since this is a YAML file
+it makes sense to use a .yml extension, though it's not required.
+Defaults to 'ia_changelog.yml'.
+
+=head1 CONTRIBUTING
+
+To browse the repository, submit issues, or bug fixes, please visit
+the github repository:
+
+=over 4
+
+L<https://github.com/duckduckgo/p5-dzp-iachangelog>
+
+=back
+
+=head1 AUTHOR
+
+Zach Thompson <zach@duckduckgo.com>
+
+=cut

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -44,9 +44,9 @@ sub gather_files {
 
     my %decode_status = qw(
         A added
-        D removed
-        M updated
-        R updated
+        D deleted
+        M modified
+        R modified
     );
 
     my $ia_types = qr/(?:goodie|spice|fathead|longtail)/i;

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -96,8 +96,9 @@ sub gather_files {
                     $status = 'M';
                 }
             } while $sd =~ s|/[^/]+$||;
+
             unless($id){
-                $s->log_fatal(["Failed to find share path for $sd in share_paths"]);
+                $s->log_fatal(["Failed to find to which instant answer share asset $f belongs!"]);
             }
         }
 

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -72,9 +72,16 @@ sub gather_files {
                 }
             }
         }
-        elsif($file =~ m{share/goodie/cheat_sheets/json/.+\.json$}){
-            my $j = decode_json(io($file)->slurp);
-            $id = $j->{id};
+        elsif($file =~ m{share/goodie/cheat_sheets/json/(.+)\.json$}){
+            if($status eq 'D'){
+                $id = $1;
+                $id =~ s/-/_/g;
+                $id .= '_cheat_sheet';
+            }
+            else{
+                my $j = decode_json(io($file)->slurp);
+                $id = $j->{id};
+            }
         }
         elsif($file =~ m{(share/$ia_types/.+)/.+$}){
             my $sd = $1;

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -98,7 +98,7 @@ sub gather_files {
             } while $sd =~ s|/[^/]+$||;
 
             unless($id){
-                $s->log_fatal(["Failed to find to which instant answer share asset $f belongs!"]);
+                $s->log_fatal(["Failed to find to which instant answer share asset $file belongs!"]);
             }
         }
 


### PR DESCRIPTION
Dzil plugin to add an instant answer change log to a release.  The change log is in YAML format for easy reading and later parsing on the community platform, e.g.

``` YAML

---
bbcode_cheat_sheet: added
gimp_cheat_sheet: updated
password: updated
sms_cheat_sheet: added
vagrant_cheat_sheet: added
bad_ol_ia: removed
```
