### PR TITLE
Missing IA page

### DIFF
--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -105,9 +105,9 @@ sub gather_files {
             } while $sd =~ s|/[^/]+$||;
 
             unless($id){
-				my $msg = ["Failed to find to which instant answer share asset $file belongs!"];
+                my $msg = ["Failed to find to which instant answer share asset $file belongs!"];
                 $stats eq 'D' $s->log_debug($msg) : $s->log_fatal($msg);
-				next;
+                next;
             }
         }
 

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -106,7 +106,7 @@ sub gather_files {
 
             unless($id){
                 my $msg = ["Failed to find to which instant answer share asset $file belongs!"];
-                $status eq 'D' $s->log_debug($msg) : $s->log_fatal($msg);
+                $status eq 'D' ? $s->log_debug($msg) : $s->log_fatal($msg);
                 next;
             }
         }

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -105,7 +105,8 @@ sub gather_files {
             } while $sd =~ s|/[^/]+$||;
 
             unless($id){
-                $s->log_fatal(["Failed to find to which instant answer share asset $file belongs!"]);
+                $s->log_debug(["Failed to find to which instant answer share asset $file belongs!"]);
+				next;
             }
         }
 

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -105,7 +105,8 @@ sub gather_files {
             } while $sd =~ s|/[^/]+$||;
 
             unless($id){
-                $s->log_debug(["Failed to find to which instant answer share asset $file belongs!"]);
+				my $msg = ["Failed to find to which instant answer share asset $file belongs!"];
+                $stats eq 'D' $s->log_debug($msg) : $s->log_fatal($msg);
 				next;
             }
         }

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -106,7 +106,7 @@ sub gather_files {
 
             unless($id){
                 my $msg = ["Failed to find to which instant answer share asset $file belongs!"];
-                $stats eq 'D' $s->log_debug($msg) : $s->log_fatal($msg);
+                $status eq 'D' $s->log_debug($msg) : $s->log_fatal($msg);
                 next;
             }
         }


### PR DESCRIPTION
When an IA page is missing, use debug when deleting a file, otherwise fatal.
