### PR TITLE
Fix IA removal with shared assets

### DIFF
--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -109,8 +109,8 @@ sub gather_files {
                 $status eq 'D' ? $s->log_debug($msg) : $s->log_fatal($msg);
                 next;
             }
-            # Skip if this has already been set to deleted, e.g. the entire IA has been removed
-            next if $changes{$id} eq 'deleted';
+            # Skip if this has been set, so we don't overwrite added/deleted 
+            next if exists $changes{$id};
         }
 
         if($id){

--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -109,10 +109,12 @@ sub gather_files {
                 $status eq 'D' ? $s->log_debug($msg) : $s->log_fatal($msg);
                 next;
             }
+            # Skip if this has already been set to deleted, e.g. the entire IA has been removed
+            next if $changes{$id} eq 'deleted';
         }
 
         if($id){
-            $changes{$id} = $decode_status{$status}
+            $changes{$id} = $decode_status{$status};
         }
         else{
             $s->log_debug(["No id found for $file"]);


### PR DESCRIPTION
Currently it's possible for an IA with shared assets that's been removed to be listed as `modified` instead of `deleted`.  This change ignores setting the status for an IA if it's already been set to `deleted` which can only happen when either the module or the json file for a cheat sheet has been removed.
