### PR TITLE
Detect renames better

### DIFF
--- a/lib/Dist/Zilla/Plugin/IAChangelog.pm
+++ b/lib/Dist/Zilla/Plugin/IAChangelog.pm
@@ -79,6 +79,9 @@ sub gather_files {
                     }
                     $id = $ia->[0]{id};
                 }
+                else{
+                    $s->log_fatal(["Failed to look upmetadata for $m"]);
+                }
             }
         }
         elsif($file =~ m{share/goodie/cheat_sheets/json/(.+)\.json$}){


### PR DESCRIPTION
Currently the `git diff` command treats renames as a delete/add.  This adds `--find-renames` and a default threshold of 50% similarity.  Right now the `cpp_algorithms` cheat sheet has been renamed.  The change correctly marks it as `modified`.
